### PR TITLE
docs: improve CLI help & set mode=slurm as default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd tests/
           crispin init
-          crispin run -profile ci_stub -stub
+          crispin run -profile ci_stub -stub --mode local
 
   build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CRISPIN development version
 
+- Improve help message for `crispin run`.
+  - the default `--mode` is now `slurm`.
+
 ## CRISPIN 1.2.0
 
 - CRISPIN now depends on ccbr_tools v0.4 for updated jobby & spooker utilities. (#63, @kelly-sovacool)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CRISPIN development version
 
-- Improve help message for `crispin run`.
+- Improve help message for `crispin run`. (#65, @kelly-sovacool)
   - the default `--mode` is now `slurm`.
 
 ## CRISPIN 1.2.0

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -53,17 +53,20 @@ def cli():
 
 help_msg_extra = """
 \b
+Nextflow options:
+-profile <profile>    Nextflow profile to use (e.g. test)
+-params-file <file>   Nextflow params file to use (e.g. assets/params.yml)
+-preview              Preview the processes that will run without executing them
+
+\b
 EXAMPLES:
 Execute with slurm:
-    crispin run ... --mode slurm
+  crispin run --output path/to/outdir --mode slurm
 Preview the processes that will run:
-    crispin run ... --mode local -preview
+  crispin run --output path/to/outdir --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-    crispin run ... -work-dir path/to/workDir
-Run with a specific installation of crispin:
-    crispin run --main path/to/crispin/main.nf ...
-Run with a specific tag, branch, or commit from GitHub:
-    crispin run --main CCBR/CRISPIN -r v0.1.0 ...
+  crispin run --output path/to/outdir --mode slurm -profile test
+  crispin run --output path/to/outdir --mode slurm -profile test -params-file assets/params.yml
 """
 
 
@@ -82,6 +85,7 @@ Run with a specific tag, branch, or commit from GitHub:
     type=str,
     default=repo_base("main.nf"),
     show_default=True,
+    hidden=True,
 )
 @click.option(
     "--output",
@@ -95,7 +99,7 @@ Run with a specific tag, branch, or commit from GitHub:
     "_mode",
     help="Run mode (slurm, local)",
     type=str,
-    default="local",
+    default="slurm",
     show_default=True,
 )
 @click.option(
@@ -109,7 +113,12 @@ Run with a specific tag, branch, or commit from GitHub:
 )
 @click.argument("nextflow_args", nargs=-1)
 def run(main_path, output, _mode, force_all, **kwargs):
-    """Run the workflow"""
+    """
+    Run the workflow
+
+    Note: you must first run `crispin init --output <output_dir>` to initialize
+    the output directory.
+    """
     if (  # this is the only acceptable github repo option for crispin
         main_path != "CCBR/CRISPIN"
     ):


### PR DESCRIPTION
## Changes

- default mode is now slurm
- hide main
- improve help message

## Issues

see https://github.com/CCBR/CCBR_NextflowTemplate/issues/49

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
