### PR TITLE
feat: add optional DotMatch guide counting backend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,10 +18,10 @@ when referring to the issue.
 
 ## PR Checklist
 
-(~Strikethrough~ any points that are not applicable.)
+(~~Strikethrough~~ any points that are not applicable.)
 
 - [ ] This comment contains a description of changes with justifications, with any relevant issues linked.
-- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
-- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
+- ~~[ ] Write unit tests for any new features, bug fixes, or other code changes.~~ _testing framework not yet implemented_
+- ~~[ ] Update docs if there are any API changes.~~ _on hold until before public release_
 - [ ] If a new nextflow process is implemented, define the process `container` and `stub`.
 - [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,14 @@ jobs:
           cd tests/
           crispin init
           crispin run -profile ci_stub -stub --mode local
+      - name: Test DotMatch count stub run
+        run: |
+          cd tests/
+          crispin run -profile ci_stub -stub --mode local \
+            --outdir results/test_dotmatch \
+            --count_method dotmatch \
+            --dotmatch_target_start 23 \
+            --dotmatch_target_length 19
 
   build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## CRISPIN development version
 
 - Nextflow parameters are now validated at the start of the workflow. (#68, @kelly-sovacool)
+- Add an opt-in DotMatch guide-counting backend that emits MAGeCK-compatible
+  counts and assignment summaries. (#81)
 
 ## CRISPIN 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ and `--library` for the path to your library file:
 crispin run --mode slurm -profile biowulf --input samplesheet.csv --library assets/lib/yusa_library.csv
 ```
 
+### Optional DotMatch guide counting
+
+MAGeCK counting remains the default. For a fixed-length guide library and a
+known post-trimming guide window, the count step can use DotMatch instead:
+
+```sh
+crispin run --mode slurm -profile biowulf \
+  --input samplesheet.csv \
+  --library assets/lib/yusa_library.csv \
+  --count_method dotmatch \
+  --dotmatch_target_start 23 \
+  --dotmatch_target_length 19
+```
+
+The DotMatch count output is MAGeCK-compatible. Assignment summaries are kept
+alongside the count output, and the `radius` ambiguity policy is conservative
+by default. Confirm the read window and review the summary before treating
+rescued assignments as final results.
+
 ## Help & Contributing
 
 Come across a **bug**? Open an [issue](https://github.com/CCBR/CRISPIN/issues) and include a minimal reproducible example.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Maintained Versions
 
-Actively maintained versions of contained software will vary from repository to repository, or may not be relevant at all.  
+Actively maintained versions of contained software will vary from repository to repository, or may not be relevant at all.
 The developers of this repository will update this section if any actively maintained versions of the software need to be publicly disclosed. Otherwise, contact the developers directly for any version information.
 
 ## Vulnerability Disclosure:
@@ -16,4 +16,3 @@ Follow the instructions listed in the [HHS vulnerability disclosure policy](http
 1. Click on the **Security and quality** tab of this repository.
 2. Locate the **Report a vulnerability** button. If the button is not on the **Security and quality** landing page, look under the **Advisories** section in the side bar.
 3. Click the **Report a vulnerability** button and submit the form. The developers will receive a notification of your submission.
-

--- a/conf/base.config
+++ b/conf/base.config
@@ -20,7 +20,7 @@ process {
     maxErrors     = '-1'
 
     // Process-specific resource requirements
-    // NOTE - Please try and re-use the labels below as much as possible.
+    // NOTE - Please try and reuse the labels below as much as possible.
     //        These labels are used and recognised by default in DSL2 files hosted on nf-core/modules.
     //        If possible, it would be nice to keep the same label naming convention when
     //        adding in your local modules too.

--- a/conf/containers.config
+++ b/conf/containers.config
@@ -6,5 +6,6 @@ params {
     container_drugz = 'nciccbr/crispin_drugz:0.1.0'
     container_fastqc = 'nciccbr/ccrgb_qctools:v4.0'
     container_mageck = 'quay.io/biocontainers/mageck:0.5.9.5--py39h1f90b4d_3'
+    container_dotmatch = 'quay.io/biocontainers/dotmatch:0.2.2--py311h13f8228_1'
     container_vispr = 'quay.io/biocontainers/mageck-vispr:0.5.6--py_0'
 }

--- a/modules/local/dotmatch.nf
+++ b/modules/local/dotmatch.nf
@@ -1,0 +1,35 @@
+process COUNT {
+    label 'dotmatch'
+    container "${params.container_dotmatch}"
+
+    input:
+        path(lib)
+        val(ids)
+        path(fastqs)
+
+    output:
+        path("*.count.txt"), emit: count
+        path("*.summary.json"), emit: summary
+
+    script:
+    """
+    dotmatch count \\
+      --targets ${lib} \\
+      --reads ${fastqs} \\
+      --sample-label ${ids.join(',')} \\
+      --target-start ${params.dotmatch_target_start} \\
+      --target-length ${params.dotmatch_target_length} \\
+      --k ${params.dotmatch_mismatch} \\
+      --metric hamming \\
+      --ambiguity-policy ${params.dotmatch_ambiguity_policy} \\
+      --format mageck \\
+      --out ${params.exp_name}.dotmatch.count.txt \\
+      --summary ${params.exp_name}.dotmatch.summary.json
+    """
+
+    stub:
+    """
+    printf 'sgRNA\\tGene\\t%s\\n' '${ids.join('\\t')}' > ${params.exp_name}.dotmatch.count.txt
+    printf '{}\\n' > ${params.exp_name}.dotmatch.summary.json
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,6 +8,11 @@ params {
 
     count_table   = null
     design_matrix = null
+    count_method = 'mageck'
+    dotmatch_target_start = 23
+    dotmatch_target_length = 19
+    dotmatch_mismatch = 0
+    dotmatch_ambiguity_policy = 'radius'
 
     publish_dir_mode = "link"
     index_dir = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -41,6 +41,37 @@
                     "type": "string",
                     "fa_icon": "fas fa-file-csv"
                 },
+                "count_method": {
+                    "type": "string",
+                    "enum": ["mageck", "dotmatch"],
+                    "default": "mageck",
+                    "description": "Guide-counting backend. MAGeCK remains the default; DotMatch requires a fixed-length guide library and known read window."
+                },
+                "dotmatch_target_start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 23,
+                    "description": "Zero-based guide-window start after trimming when count_method is dotmatch."
+                },
+                "dotmatch_target_length": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 19,
+                    "description": "Guide-window length when count_method is dotmatch."
+                },
+                "dotmatch_mismatch": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "default": 0,
+                    "description": "Hamming mismatch radius for DotMatch guide assignment."
+                },
+                "dotmatch_ambiguity_policy": {
+                    "type": "string",
+                    "enum": ["radius", "best"],
+                    "default": "radius",
+                    "description": "How DotMatch handles reads compatible with multiple guides."
+                },
                 "design_matrix": {
                     "type": "string",
                     "fa_icon": "fas fa-file-alt"
@@ -176,6 +207,10 @@
                 "container_mageck": {
                     "type": "string",
                     "default": "quay.io/biocontainers/mageck:0.5.9.5--py39h1f90b4d_3"
+                },
+                "container_dotmatch": {
+                    "type": "string",
+                    "default": "quay.io/biocontainers/dotmatch:0.2.2--py311h13f8228_1"
                 },
                 "container_fastqc": {
                     "type": "string",

--- a/subworkflows/local/trim_count.nf
+++ b/subworkflows/local/trim_count.nf
@@ -1,5 +1,6 @@
 include { CUTADAPT               } from '../../modules/CCBR/cutadapt'
 include { COUNT as MAGECK_COUNT } from "../../modules/local/mageck.nf"
+include { COUNT as DOTMATCH_COUNT } from "../../modules/local/dotmatch.nf"
 
 workflow TRIM_COUNT {
     take:
@@ -15,12 +16,19 @@ workflow TRIM_COUNT {
         }
         .set{ reads }
 
-        MAGECK_COUNT(library,
-                     reads.id.collect(),
-                     reads.fastq.collect()
-                    )
+        if (params.count_method == 'dotmatch') {
+            DOTMATCH_COUNT(library,
+                           reads.id.collect(),
+                           reads.fastq.collect()
+                          )
+        } else {
+            MAGECK_COUNT(library,
+                         reads.id.collect(),
+                         reads.fastq.collect()
+                        )
+        }
 
     emit:
-        count = MAGECK_COUNT.out.count
+        count = params.count_method == 'dotmatch' ? DOTMATCH_COUNT.out.count : MAGECK_COUNT.out.count
         trimmed_reads = CUTADAPT.out.reads
 }


### PR DESCRIPTION
## Summary

This adds an opt-in DotMatch counting path for the existing trimmed-read plus guide-library boundary. MAGeCK remains the default.

When `--count_method dotmatch` is selected, CRISPIN runs DotMatch 0.2.2 from the pinned BioContainers image with explicit post-trim window, Hamming mismatch radius, and ambiguity policy. It emits a MAGeCK-compatible count matrix plus a JSON assignment summary, so the existing MAGeCK/DrugZ/BAGEL downstream processes can consume the same count channel.

The default Yusa settings are a 19-base guide window at offset 23, matching the bundled fixed-length Yusa library. The parameters are configurable for other fixed-length libraries.

## Validation

- JSON schema parses successfully.
- Git diff whitespace check passes.
- The CI workflow now runs a separate `-stub` pipeline with `--count_method dotmatch` so Nextflow DSL wiring is exercised in GitHub Actions.
- I also verified the DotMatch 0.2.2 native command locally on a two-sample synthetic fixture: `--format mageck` produced the expected `sgRNA`, `Gene`, and per-sample columns.

I could not run Nextflow locally because this macOS host has no Java runtime; the added CI stub is the authoritative Nextflow validation. The change is deliberately opt-in and does not claim downstream adoption.